### PR TITLE
US - 6.2.1 Select POI as destination for directions

### DIFF
--- a/frontend/where2go/App.js
+++ b/frontend/where2go/App.js
@@ -50,6 +50,7 @@ export default function App() {
   //for selecting buildings as departure or destination on map
   const [departureBuilding, setDepartureBuilding] = useState(null);
   const [destinationBuilding, setDestinationBuilding] = useState(null);
+  const [destinationPoi, setDestinationPoi] = useState(null);
   const getBuildingRole = (building) => {
     if (building?.id === departureBuilding?.id) return 'departure';
     if (building?.id === destinationBuilding?.id) return 'destination';
@@ -212,13 +213,14 @@ export default function App() {
   }
 
   if(showOutdoorDirection){
-    return <OutdoorDirection 
-    onPressBack={() => setShowOutdoorDirection((prev) => (prev !== true))} 
-    buildings={buildings} 
+    return <OutdoorDirection
+    onPressBack={() => setShowOutdoorDirection((prev) => (prev !== true))}
+    buildings={buildings}
     initialFrom={departureBuilding ? departureBuilding.name : ""}
     initialTo={destinationBuilding ? destinationBuilding.name : ""}
+    destination={destinationPoi}
     />;
-  
+
   }
 
   return (
@@ -331,13 +333,26 @@ export default function App() {
         visible={modalVisible}
         onClose={() => setModalVisible(false)}
         onSetDeparture={(buildingCommute) => setDepartureBuilding(buildingCommute)}
-        onSetDestination={(buildingCommute) => setDestinationBuilding(buildingCommute)}
+        onSetDestination={(buildingCommute) => {
+          setDestinationBuilding(buildingCommute);
+          setDestinationPoi(null);
+        }}
         selectedRole={ getBuildingRole(selectedBuilding) }
       />
       <PoiInfoModal
         poi={selectedPoi}
         visible={poiModalVisible}
         onClose={() => setPoiModalVisible(false)}
+        onSetAsDestination={() => {
+          setDestinationPoi({
+            label: selectedPoi.name,
+            lat: selectedPoi.geometry.location.lat,
+            lng: selectedPoi.geometry.location.lng,
+          });
+          setDestinationBuilding(null);
+          setPoiModalVisible(false);
+          setShowOutdoorDirection(true);
+        }}
       />
       {isPressedPOI && (
         <PoiSlider

--- a/frontend/where2go/__tests__/PoiInfoModal.test.js
+++ b/frontend/where2go/__tests__/PoiInfoModal.test.js
@@ -51,7 +51,7 @@ describe('PoiInfoModal', () => {
         const { getByText } = render(
             <PoiInfoModal poi={POI} visible={true} onClose={jest.fn()} onSetAsDestination={onSetAsDestination} />
         );
-        fireEvent.press(getByText('Set as destination'));
+        fireEvent.press(getByText('Get directions'));
         expect(onSetAsDestination).toHaveBeenCalledTimes(1);
     });
 

--- a/frontend/where2go/src/PoiInfoModal.js
+++ b/frontend/where2go/src/PoiInfoModal.js
@@ -88,7 +88,7 @@ const PoiInfoModal = ({ poi, visible, onClose, onSetAsDestination }) => {
               onPress={onSetAsDestination ?? (() => {})}
             >
               <Ionicons name="navigate" size={18} color="#fff" />
-              <Text style={styles.primaryButtonText}>Set as destination</Text>
+              <Text style={styles.primaryButtonText}>Get directions</Text>
             </Pressable>
 
             {/* Close secondary button */}


### PR DESCRIPTION
### Description

- When you tap "Get directions" button in PoiInfoModal, POI is set as the destination and the OutdoorDirection screen opens
- Setting a building as destination clears any POI destination and vice versa

### Checklist

- [x] Tapping a POI marker opens the POI modal with name, rating, address, and picture
- [x] When you press "Get directions" , the modal closes and the Plan Your Trip view is shown , where you can see the POI name pre-filled in the "To" field

### What should still be working

- Building "Set as Departure" / "Set as Destination" flow is still the same
- POI markers still render on the map and open the modal correctly

closes #112 