### PR TITLE
Displayed Calender UI

### DIFF
--- a/frontend/where2go/__tests__/CalendarPage.test.js
+++ b/frontend/where2go/__tests__/CalendarPage.test.js
@@ -515,37 +515,33 @@ describe('CalendarPage', () => {
         expect(getByTestId('bottom-sheet-view')).toBeTruthy();
     });
 
-    it('toggles calendar selection: adds on first click, removes on second', async () => {
-        // Mock the calendar data
-        Calendar.requestCalendarPermissionsAsync.mockResolvedValue({ status: 'granted' });
-        Calendar.getCalendarsAsync.mockResolvedValue([
-            { id: 'cal-1', title: 'Work', color: 'blue' }
-        ]);
+    it("toggles calendar selection: add then remove; Done still proceeds to calendar view (0 calendars)", async () => {
+  Calendar.requestCalendarPermissionsAsync.mockResolvedValue({ status: "granted" });
+  Calendar.getCalendarsAsync.mockResolvedValue([{ id: "cal-1", title: "Work", color: "blue" }]);
 
-        const { getByTestId, findByText } = render(<CalendarPage onPressBack={jest.fn()} />);
+  const { getByTestId, getByText, findByText, queryByText, getByLabelText} = render(
+    <CalendarPage onPressBack={jest.fn()} />
+  );
 
-        // 1. Open modal and connect to see the checkboxes
-        fireEvent.press(getByTestId('openModalBtn'));
-        fireEvent.press(getByTestId('calBtn'));
-        await findByText('Work');
+  fireEvent.press(getByTestId("openModalBtn"));
+  fireEvent.press(getByTestId("calBtn"));
+  await findByText("Work");
 
-        const checkbox = getByTestId('checkbox-cal-1');
+  // add then remove
+  fireEvent(getByTestId("checkbox-cal-1"), "onValueChange", true);
+  fireEvent(getByTestId("checkbox-cal-1"), "onValueChange", false);
 
-        // 2. First Click: Should ADD 'cal-1' to selectedCalendarIds
-        fireEvent(checkbox, 'onValueChange', true);
+  fireEvent.press(getByText("Done"));
 
-        // 3. Second Click: Should REMOVE 'cal-1' (the .filter() logic)
-        fireEvent(checkbox, 'onValueChange', false);
+  // ✅ should be in calendar view now
+  expect(await findByText("Upcoming Events")).toBeTruthy();
 
-        // 4. Verify the state by checking if "Done" works correctly
-        // If it was removed, clicking "Done" shouldn't trigger the next view 
-        // because you have: onPress={() => setIsCalendarsChosen(selectedCalendarIds.length > 0)}
-        fireEvent.press(getByTestId('saveBtn'));
+  // press a day -> early return branch (no selected calendars)
+  fireEvent.press(getByTestId("mock-calendar"));
 
-        // The "Extracting Calendars" text should still be there if selection is 0
-        expect(await findByText('Extracting Calendars')).toBeTruthy();
-    });
+  expect(queryByText("No events for this day")).toBeTruthy();
 });
+
 it("toggles full calendar view and presses CalendarList day (covers CalendarList path)", async () => {
   Calendar.requestCalendarPermissionsAsync.mockResolvedValue({ status: "granted" });
   Calendar.getCalendarsAsync.mockResolvedValue([{ id: "cal-1", title: "Work", color: "#123456" }]);
@@ -615,7 +611,7 @@ it('pressing "Change" in Selected Calendars modal returns to "Extracting Calenda
   fireEvent.press(getByLabelText("Selected calendars"));
   await findByText("Selected Calendars");
 
-  fireEvent.press(getByText("Change"));
+  fireEvent.press(getByTestId("selectedCalsChangeBtn"));
 
   expect(await findByText(/Extracting Calendars/i)).toBeTruthy();
   expect(await findByText(/Select Desired Calendars to Extract/i)).toBeTruthy();
@@ -648,4 +644,146 @@ it("renders date parts from event startDate (covers monthShort + getDatePartsFro
   expect(await findByText("December Event")).toBeTruthy();
   // Month short should appear as DEC somewhere in the event card
   expect(await findByText("DEC")).toBeTruthy();
+});
+
+it("Selected Calendars modal: content press does not close, overlay/close button do close", async () => {
+  Calendar.requestCalendarPermissionsAsync.mockResolvedValue({ status: "granted" });
+  Calendar.getCalendarsAsync.mockResolvedValue([{ id: "cal-1", title: "Work", color: "#ff0000" }]);
+  Calendar.getEventsAsync.mockResolvedValue([]);
+
+  const { getByTestId, getByText, findByText, queryByText, getByLabelText } =
+    render(<CalendarPage />);
+
+  fireEvent.press(getByTestId("openModalBtn"));
+  fireEvent.press(getByTestId("calBtn"));
+
+  await findByText("Work");
+  fireEvent(getByTestId("checkbox-cal-1"), "onValueChange", true);
+  fireEvent.press(getByText("Done"));
+
+  // open selected calendars modal (your trigger must have accessibilityLabel="Selected calendars")
+  fireEvent.press(getByLabelText("Selected calendars"));
+  expect(await findByText("Selected Calendars")).toBeTruthy();
+
+  // press inside modal content -> should NOT close
+  fireEvent.press(getByTestId("selectedCalsContent"));
+  expect(queryByText("Selected Calendars")).toBeTruthy();
+
+  // press overlay -> should close
+  fireEvent.press(getByTestId("selectedCalsOverlay"));
+  await waitFor(() => {
+    expect(queryByText("Selected Calendars")).toBeNull();
+  });
+
+  // open again
+  fireEvent.press(getByLabelText("Selected calendars"));
+  expect(await findByText("Selected Calendars")).toBeTruthy();
+
+  // close button -> should close
+  fireEvent.press(getByTestId("selectedCalsCloseBtn"));
+  await waitFor(() => {
+    expect(queryByText("Selected Calendars")).toBeNull();
+  });
+});
+
+it("Selected Calendars modal closes via Modal requestClose (covers onRequestClose)", async () => {
+  Calendar.requestCalendarPermissionsAsync.mockResolvedValue({ status: "granted" });
+  Calendar.getCalendarsAsync.mockResolvedValue([{ id: "cal-1", title: "Work", color: "#ff0000" }]);
+  Calendar.getEventsAsync.mockResolvedValue([]);
+
+  const { getByTestId, getByText, findByText, queryByText, getByLabelText } =
+    render(<CalendarPage />);
+
+  fireEvent.press(getByTestId("openModalBtn"));
+  fireEvent.press(getByTestId("calBtn"));
+
+  await findByText("Work");
+  fireEvent(getByTestId("checkbox-cal-1"), "onValueChange", true);
+  fireEvent.press(getByText("Done"));
+
+  fireEvent.press(getByLabelText("Selected calendars"));
+  expect(await findByText("Selected Calendars")).toBeTruthy();
+
+  // trigger Modal onRequestClose
+  fireEvent(getByTestId("selectedCalsModal"), "requestClose");
+
+  await waitFor(() => {
+    expect(queryByText("Selected Calendars")).toBeNull();
+  });
+});
+
+it("clears events if no calendars are selected (covers early return)", async () => {
+  Calendar.requestCalendarPermissionsAsync.mockResolvedValue({ status: "granted" });
+  Calendar.getCalendarsAsync.mockResolvedValue([{ id: "cal-1", title: "Work", color: "#ff0000" }]);
+
+  // first call returns an event
+  Calendar.getEventsAsync.mockResolvedValue([
+    { id: "e1", title: "Event 1", startDate: "2026-12-01T10:00:00.000Z", endDate: "2026-12-01T11:00:00.000Z" },
+  ]);
+
+  const { getByTestId, getByText, findByText, queryByText, getByLabelText } = render(
+    <CalendarPage onPressBack={jest.fn()} />
+  );
+
+  // connect + select calendar + Done
+  fireEvent.press(getByTestId("openModalBtn"));
+  fireEvent.press(getByTestId("calBtn"));
+  await findByText("Work");
+  fireEvent(getByTestId("checkbox-cal-1"), "onValueChange", true);
+  fireEvent.press(getByText("Done"));
+
+  // fetch events
+  fireEvent.press(getByTestId("mock-calendar"));
+  await findByText("Event 1");
+
+  // open selected calendars modal -> Change (go back to extraction)
+  fireEvent.press(getByLabelText("Selected calendars"));
+  await findByText("Selected Calendars");
+  fireEvent.press(getByTestId("selectedCalsChangeBtn"));
+
+  // unselect calendar -> Done (still proceeds to calendar view even with 0)
+  await findByText(/Select Desired Calendars to Extract/i);
+  fireEvent(getByTestId("checkbox-cal-1"), "onValueChange", false);
+  fireEvent.press(getByText("Done"));
+
+  // press a day -> early return clears events
+  await findByText("Upcoming Events");
+  fireEvent.press(getByTestId("mock-calendar"));
+
+  expect(queryByText("Event 1")).toBeNull();
+  expect(queryByText("No events for this day")).toBeTruthy();
+});
+
+it("pressing an event logs Selected event (covers line 254)", async () => {
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+  Calendar.requestCalendarPermissionsAsync.mockResolvedValue({ status: "granted" });
+  Calendar.getCalendarsAsync.mockResolvedValue([{ id: "cal-1", title: "Work", color: "#ff0000" }]);
+  Calendar.getEventsAsync.mockResolvedValue([
+    {
+      id: "e1",
+      title: "Event 1",
+      startDate: "2026-12-01T10:00:00.000Z",
+      endDate: "2026-12-01T11:00:00.000Z",
+      location: "Hall",
+    },
+  ]);
+
+  const { getByTestId, getByText, findByText } = render(<CalendarPage onPressBack={jest.fn()} />);
+
+  fireEvent.press(getByTestId("openModalBtn"));
+  fireEvent.press(getByTestId("calBtn"));
+  await findByText("Work");
+  fireEvent(getByTestId("checkbox-cal-1"), "onValueChange", true);
+  fireEvent.press(getByText("Done"));
+
+  fireEvent.press(getByTestId("mock-calendar"));
+  await findByText("Event 1");
+
+  fireEvent.press(getByTestId("event-item-e1"));
+  expect(logSpy).toHaveBeenCalledWith("Selected event:", "Event 1");
+
+  logSpy.mockRestore();
+});
+
 });

--- a/frontend/where2go/src/CalendarPage.js
+++ b/frontend/where2go/src/CalendarPage.js
@@ -282,7 +282,7 @@ export default function CalendarPage({ onPressBack }) {
               </ScrollView>
             </View>
 
-            <Modal
+            {/* <Modal
               transparent
               visible={selectedCalsModalVisible}
               animationType="fade"
@@ -333,7 +333,68 @@ export default function CalendarPage({ onPressBack }) {
                   </Pressable>
                 </Pressable>
               </Pressable>
-            </Modal>
+            </Modal> */}
+           <Modal
+  testID="selectedCalsModal"
+  transparent
+  visible={selectedCalsModalVisible}
+  animationType="fade"
+  onRequestClose={() => setSelectedCalsModalVisible(false)}
+>
+  <Pressable
+    testID="selectedCalsOverlay"
+    style={styles.modalOverlay}
+    onPress={() => setSelectedCalsModalVisible(false)}
+  >
+    <Pressable
+      testID="selectedCalsContent"
+      style={styles.selectedCalsModal}
+      onPress={() => {}}
+    >
+      <View style={styles.selectedCalsHeader}>
+        <Text style={styles.selectedCalsTitle}>Selected Calendars</Text>
+
+        <Pressable
+          testID="selectedCalsCloseBtn"
+          onPress={() => setSelectedCalsModalVisible(false)}
+        >
+          <Ionicons name="close" size={20} color="#333" />
+        </Pressable>
+      </View>
+
+      {chosenCalendars.length === 0 ? (
+        <Text style={styles.selectedCalsEmpty}>
+          No calendars selected. Tap “Change” to choose calendars.
+        </Text>
+      ) : (
+        chosenCalendars.map((cal) => (
+          <View key={cal.id} style={styles.calRow}>
+            <View
+              style={[
+                styles.colorDot,
+                { backgroundColor: cal.color || "#912338" },
+              ]}
+            />
+            <Text style={styles.calName} numberOfLines={1}>
+              {cal.title}
+            </Text>
+          </View>
+        ))
+      )}
+
+      <Pressable
+        testID="selectedCalsChangeBtn"
+        style={styles.changeBtn}
+        onPress={() => {
+          setSelectedCalsModalVisible(false);
+          setIsCalendarsChosen(false);
+        }}
+      >
+        <Text style={styles.changeBtnTxt}>Change</Text>
+      </Pressable>
+    </Pressable>
+  </Pressable>
+</Modal>
           </View>
         ) : (
           <>
@@ -358,7 +419,8 @@ export default function CalendarPage({ onPressBack }) {
 
               <Pressable
                 style={styles.saveBtn}
-                onPress={() => setIsCalendarsChosen(selectedCalendarIds.length > 0)}
+                onPress={() => setIsCalendarsChosen(true)}
+                //onPress={() => setIsCalendarsChosen(selectedCalendarIds.length > 0)}
               >
                 <Text testID="saveBtn" style={styles.btnTxt}>
                   Done


### PR DESCRIPTION
Description
Task was to improve the displayed Calendar UI. Once users connect their calendar with Google Calendar, choose which calendars they want to extract events from, and view events by selecting a date, these information must be displayed on the calendar UI. The Calendar page layout was updated to match the Figma mockups, and event cards were enhanced to display more useful information including time. 

Checklist
- Calendar bottom slide panel can be opened and closed
- Back button returns to previous page
- A calendar icon shows up on the first page when no calendar is connected
- Extracting calendar page fits the screen layout correctly
- Calendar page UI matches the Figma layout (calendar card + upcoming events section)
- Events display includes title, time

What should still be working?
The overall Navigation functionality remains unchanged. For extracting calendar you need to use your real device to test it