### PR TITLE
Added "manually add events" to calendarPage

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@googlemaps/markerclusterer": "^2.5.1",
         "@mapbox/polyline": "^1.2.1",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/datetimepicker": "8.4.4",
         "@react-native-community/slider": "^5.1.2",
         "@vis.gl/react-google-maps": "latest",
         "expo": "~54.0.33",
@@ -3287,6 +3288,29 @@
       "license": "MIT",
       "dependencies": {
         "joi": "^17.2.1"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.4.tgz",
+      "integrity": "sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-community/slider": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@googlemaps/markerclusterer": "^2.5.1",
     "@mapbox/polyline": "^1.2.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-native-community/slider": "^5.1.2",
     "@vis.gl/react-google-maps": "latest",
     "expo": "~54.0.33",

--- a/client/src/CalendarManuallyAdd.js
+++ b/client/src/CalendarManuallyAdd.js
@@ -1,0 +1,286 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  Modal,
+  TextInput,
+  Pressable,
+  Platform,
+  TouchableWithoutFeedback, 
+  Keyboard,
+  FlatList,
+} from "react-native";
+import { styles } from "./styles/CalendarManuallyAdd_styles";
+import DateTimePicker from "@react-native-community/datetimepicker";
+
+const buildings = [
+  // SGW
+  "Hall Building",
+  "McConnell Building",
+  "Visual Arts Building",
+  "Engineering & Visual Arts",
+  "Grey Nuns Building",
+  "Faubourg Building (FG)",
+  "CL Annex Building",
+  "Toronto-Dominion Building",
+  "John Molson School of Business (JMSB)",
+  "Guy-de Maisonneuve Building",
+  "Learning Square Building",
+  "ER Building",
+  "GS Building",
+  "Samuel Bronfman Building",
+  "Q Annex",
+  "P Annex",
+  "T Annex",
+  "RR Annex",
+  "R Annex",
+  "FA Annex",
+  "EN Annex",
+  "X Annex",
+  "Z Annex",
+  "PR Annex",
+  "V Annex",
+  "M Annex",
+  "S Annex",
+  "CI Annex",
+  "MI Annex",
+  "D Annex",
+  "B Annex",
+  "K Annex",
+  "MU Annex",
+  // Loyola
+  "Stinger Dome Building",
+  "PERFORM Centre",
+  "Recreation and Athletics Complex",
+  "Centre for Structural and Functional Genomics",
+  "Communications Studies and Journalism Building",
+  "Richard J. Renaud Science Complex",
+  "Administration Building",
+  "Central Building",
+  "Loyola Jesuit Hall and Conference Centre",
+  "F.C. Smith Building",
+  "Quadrangle",
+  "Psychology Building",
+  "Vanier Extension",
+  "Vanier Library Building",
+  "Oscar Peterson Concert Hall",
+  "Student Centre",
+  "BH Annex",
+  "BB Annex",
+  "Physical Services Building",
+  "St. Ignatius of Loyola Church",
+  "Jesuit Residence",
+  "Applied Science Hub",
+  "Hingston Hall, wing HB",
+  "Future Buildings Laboratory",
+  "Terrebone Building",
+];
+
+export default function CalendarManuallyAdd({ visible, onClose, onSave }) {
+  const [title, setTitle] = useState("");
+  const [location, setLocation] = useState("");
+  const [roomNumber, setRoomNumber] = useState("");
+
+  const [date, setDate] = useState(new Date());
+  const [startTime, setStartTime] = useState(new Date());
+  const [endTime, setEndTime] = useState(new Date());
+
+  const [showDate, setShowDate] = useState(false);
+  const [showStart, setShowStart] = useState(false);
+  const [showEnd, setShowEnd] = useState(false);
+
+  // autocomplete building name
+  const [filteredBuildings, setFilteredBuildings] = useState([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const saveEvent = () => {
+    const startDateEvent = new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      startTime.getHours(),
+      startTime.getMinutes()
+    );
+    const endDateEvent = new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      endTime.getHours(),
+      endTime.getMinutes()
+    );
+
+    if (endDateEvent <= startDateEvent) {
+      alert("End time must be after start time");
+      return;
+    }
+    
+    if (!title.trim()) {
+      alert("Please enter an event title");
+      return;
+    }
+    if (!location.trim()) {
+      alert("Please enter a valid location");
+      return;
+    }
+
+    const newEvent = {
+      id: `manual-${Date.now()}`,
+      title,
+      location,
+      roomNumber: roomNumber.trim() || null,
+      startDate: startDateEvent,
+      endDate: endDateEvent,
+      isManual: true
+    };
+
+    onSave(newEvent);
+    onClose();
+
+    setTitle("");
+    setLocation("");
+    setRoomNumber("");
+  };
+
+  const handleLocationChange = (text) => {
+    setLocation(text);
+
+    if (text.length === 0) {
+        setFilteredBuildings([]);
+        setShowSuggestions(false);
+        return;
+    }
+
+    const query = text.toLowerCase();
+    
+    const matches = buildings
+        .filter((b) => {
+            const lower = b.toLowerCase();
+            return lower.startsWith(query) || lower.includes(` ${query}`);
+        })
+        .slice(0, 5);
+
+    setFilteredBuildings(matches);
+    setShowSuggestions(matches.length > 0);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback
+            onPress={() => {
+            Keyboard.dismiss();
+            setShowSuggestions(false);
+            }}
+        >
+        <View style={styles.container}>
+
+          <Text style={styles.title}>Add Event</Text>
+
+          <TextInput
+            placeholder="Event title"
+            value={title}
+            onChangeText={setTitle}
+            style={styles.input}
+          />
+
+          <TextInput
+            placeholder="Building Location"
+            value={location}
+            onChangeText={handleLocationChange}
+            style={styles.input}
+          />
+
+          <TextInput
+            placeholder="Room Number (Optional)"
+            value={roomNumber}
+            onChangeText={setRoomNumber}
+            style={styles.input}
+          />
+
+          {showSuggestions && filteredBuildings.length > 0 && (
+            <FlatList
+              data={filteredBuildings}
+              keyExtractor={(item) => item}
+              renderItem={({ item: building }) => (
+                <Pressable
+                  style={styles.suggestionItem}
+                  onPress={() => {
+                    setLocation(building);
+                    setShowSuggestions(false);
+                    Keyboard.dismiss();
+                  }}
+                >
+                  <Text>{building}</Text>
+                </Pressable>
+              )}
+              style={styles.suggestionsBox}
+              nestedScrollEnabled={true}
+              scrollEnabled={true}
+            />
+          )}
+
+          <Pressable onPress={() => setShowDate(true)} style={styles.selector}>
+            <Text>Select Date: {date.toDateString()}</Text>
+          </Pressable>
+
+          {showDate && (
+            <DateTimePicker
+              value={date}
+              mode="date"
+              onChange={(e, d) => {
+                setShowDate(Platform.OS === "ios");
+                if (d) setDate(d);
+              }}
+            />
+          )}
+
+          <Pressable onPress={() => setShowStart(true)} style={styles.selector}>
+            <Text>
+              Start Time: {startTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </Text>
+          </Pressable>
+
+          {showStart && (
+            <DateTimePicker
+              value={startTime}
+              mode="time"
+              onChange={(e, d) => {
+                setShowStart(Platform.OS === "ios");
+                if (d) setStartTime(d);
+              }}
+            />
+          )}
+
+          <Pressable onPress={() => setShowEnd(true)} style={styles.selector}>
+            <Text>
+              End Time: {endTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </Text>
+          </Pressable>
+
+          {showEnd && (
+            <DateTimePicker
+              value={endTime}
+              mode="time"
+              onChange={(e, d) => {
+                setShowEnd(Platform.OS === "ios");
+                if (d) setEndTime(d);
+              }}
+            />
+          )}
+
+          <View style={styles.row}>
+            <Pressable style={styles.cancel} onPress={onClose}>
+              <Text style={styles.btnText}>Cancel</Text>
+            </Pressable>
+
+            <Pressable style={styles.save} onPress={saveEvent}>
+              <Text style={styles.btnText}>Save</Text>
+            </Pressable>
+          </View>
+
+        </View>
+        </TouchableWithoutFeedback>
+      </View>
+    </Modal>
+  );
+}

--- a/client/src/CalendarPage.js
+++ b/client/src/CalendarPage.js
@@ -2,7 +2,6 @@ import React, { useRef, useState, useEffect } from "react";
 import {
   View,
   Text,
-  StyleSheet,
   Modal,
   Animated,
   PanResponder,
@@ -13,6 +12,7 @@ import {
   Alert,
   Linking,
 } from "react-native";
+import { styles } from "./styles/CalendarPage_styles";
 import { Ionicons } from "@expo/vector-icons";
 import * as WebBrowser from "expo-web-browser";
 import * as Calendar from "expo-calendar";
@@ -22,6 +22,7 @@ import PropTypes from "prop-types";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { parseEventLocation } from './utils/eventLocationParser'; // location string → { building, room }
 import { getValidCalendarIds, fetchCalendarsIfPermitted } from './utils/calendarUtils';
+import CalendarManuallyAdd from "./CalendarManuallyAdd";
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -111,6 +112,27 @@ export default function CalendarPage({ onPressBack, onGenerateDirections }) {
   const [selectedCalsModalVisible, setSelectedCalsModalVisible] = useState(false);
 
   const [selectedDate, setSelectedDate] = useState(todayString());
+
+  const [showManualModal, setShowManualModal] = useState(false);
+  const [manualEvents, setManualEvents] = useState([]);
+
+  // Filter manual events by selected date and combine with calendar events
+  const getManualEventsForDay = (dateString) => {
+    const [year, month, day] = dateString.split("-").map(Number);
+    const targetDate = new Date(year, month - 1, day);
+    
+    return manualEvents.filter((event) => {
+      const eventDate = new Date(event.startDate);
+      return eventDate.getFullYear() === targetDate.getFullYear() &&
+             eventDate.getMonth() === targetDate.getMonth() &&
+             eventDate.getDate() === targetDate.getDate();
+    });
+  };
+
+  const manualEventsForDay = getManualEventsForDay(selectedDate);
+  const allEvents = [...events, ...manualEventsForDay].sort((a, b) => 
+    new Date(a.startDate) - new Date(b.startDate)
+  );
 
   const getCalendars = async () => {
     const { status } = await Calendar.requestCalendarPermissionsAsync();
@@ -247,6 +269,10 @@ export default function CalendarPage({ onPressBack, onGenerateDirections }) {
     </View>
   );
 
+  useEffect(() => {
+    console.log("manualEvents:", manualEvents);
+  }, [manualEvents]);
+
   return (
     <View style={styles.container}>
       {/* Header */}
@@ -319,13 +345,13 @@ export default function CalendarPage({ onPressBack, onGenerateDirections }) {
 
             <View style={styles.upcomingBox}>
               <ScrollView showsVerticalScrollIndicator={false}>
-                {events.length === 0 ? (
+                {allEvents.length === 0 ? (
                   <View style={styles.emptyWrap}>
                     <Text style={styles.emptyTitle}>No events for this day</Text>
                     <Text style={styles.emptySub}>Select another date to view events.</Text>
                   </View>
                 ) : (
-                  events.map((event) => {
+                  allEvents.map((event) => {
                     const { day, mon } = getDatePartsFromEvent(event);
                     const timeRange = formatTimeRange(event);
 
@@ -541,12 +567,25 @@ export default function CalendarPage({ onPressBack, onGenerateDirections }) {
             </Pressable>
 
             {/* not implemented yet*/}
-            <Pressable style={styles.manualBtn}>
+            <Pressable
+              style={styles.manualBtn}
+              onPress={() => {
+                close();
+                setShowManualModal(true);
+              }}
+            >
               <Text style={styles.btnTxt}>Manually Add Events</Text>
             </Pressable>
           </Animated.View>
         </View>
       </Modal>
+      <CalendarManuallyAdd
+            visible={showManualModal}
+            onClose={() => setShowManualModal(false)}
+            onSave={(event) => {
+              setManualEvents((prev) => [...prev, event]);
+            }}
+          />
     </View>
   );
 }
@@ -558,318 +597,4 @@ CalendarPage.propTypes = {
   onGenerateDirections: PropTypes.func,
 };
 
-/* Styles CSS*/
-const styles = StyleSheet.create({
-  container: { flex: 1 },
-
-  header: {
-    height: 100,
-    backgroundColor: "#912338",
-    paddingTop: 35,
-    paddingHorizontal: 16,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  headerBtn: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-
-  buttonModalUp: {
-    backgroundColor: "#912338",
-    padding: 12,
-    borderRadius: 50,
-    position: "absolute",
-    bottom: 25,
-    right: 15,
-    justifyContent: "center",
-  },
-
-  overlay: {
-    flex: 1,
-    justifyContent: "flex-end",
-    backgroundColor: "rgba(0,0,0,0.4)",
-  },
-  sheet: {
-    height: SHEET_HEIGHT,
-    backgroundColor: "white",
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    padding: 20,
-    justifyContent: "center",
-    flexDirection: "column",
-    gap: 20,
-  },
-  handle: {
-    width: 50,
-    height: 6,
-    backgroundColor: "#ccc",
-    borderRadius: 10,
-    alignSelf: "center",
-    position: "absolute",
-    top: 10,
-    marginBottom: 15,
-  },
-  closeBtn: {
-    position: "absolute",
-    top: 10,
-    right: 10,
-    zIndex: 12,
-  },
-
-  googleCalBtn: {
-    backgroundColor: "#912338",
-    padding: 12,
-    borderRadius: 50,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  manualBtn: {
-    backgroundColor: "#912338",
-    padding: 12,
-    borderRadius: 50,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  btnTxt: { color: "white", fontWeight: "bold" },
-
-  calendar: {
-    width: 150,
-    height: 150,
-    marginBottom: 10,
-    borderRadius: 45,
-  },
-  txtNoCal: { fontSize: 30, fontWeight: "700" },
-  noCalContainer: {
-    flex: 1,
-    justifyContent: "flex-start",
-    alignItems: "center",
-    marginTop: 220,
-  },
-
-  titleView: {
-    backgroundColor: "#912338",
-    width: width,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  txtTitle: {
-    color: "white",
-    fontSize: 18,
-    bottom: 30,
-    fontWeight: "800",
-    fontFamily: "Helvetica Neue",
-  },
-  selectCalView: {
-    flex: 1,
-    width: "100%",
-    paddingTop: 20,
-    paddingHorizontal: 20,
-  },
-  txtSelectCal: {
-    fontSize: 18,
-    fontWeight: "700",
-    fontFamily: "Helvetica Neue",
-    marginBottom: 10,
-  },
-  checkboxRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 10,
-    paddingHorizontal: 15,
-  },
-  checkboxLabel: { marginLeft: 10, fontSize: 16 },
-  saveBtn: {
-    backgroundColor: "#912338",
-    padding: 15,
-    borderRadius: 10,
-    marginTop: 50,
-    alignItems: "center",
-  },
-
-  /* -------- Calendar page -------- */
-  pageWrap: {
-    flex: 1,
-    paddingTop: 12,
-    paddingHorizontal: 18,
-  },
-  calendarCard: {
-    borderWidth: 1,
-    borderColor: "#E9E9E9",
-    borderRadius: 16,
-    backgroundColor: "#fff",
-    padding: 10,
-  },
-  calendarTopRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingHorizontal: 6,
-    paddingTop: 2,
-    paddingBottom: 6,
-  },
-  iconBtn: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-
-  upcomingTitle: {
-    marginTop: 14,
-    marginBottom: 10,
-    fontSize: 16,
-    fontWeight: "800",
-    color: "#111",
-  },
-  upcomingBox: {
-    borderWidth: 1,
-    borderColor: "#E9E9E9",
-    borderRadius: 14,
-    backgroundColor: "#fff",
-    paddingVertical: 6,
-    paddingHorizontal: 8,
-    maxHeight: height * 0.36,
-  },
-
-  eventRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 10,
-    paddingRight: 6,
-    borderRadius: 10,
-  },
-  leftAccent: {
-    width: 3,
-    height: "70%",
-    backgroundColor: "#912338",
-    borderRadius: 4,
-    marginRight: 10,
-    marginLeft: 6,
-  },
-  dateCol: {
-    width: 46,
-    alignItems: "center",
-    justifyContent: "center",
-    marginRight: 12,
-  },
-  dateDay: {
-    fontSize: 18,
-    fontWeight: "900",
-    color: "#912338",
-    lineHeight: 20,
-  },
-  dateMonth: {
-    fontSize: 12,
-    fontWeight: "900",
-    color: "#912338",
-    marginTop: 2,
-  },
-  eventInfo: { flex: 1 },
-  eventName: { fontSize: 14, fontWeight: "900", color: "#111" },
-  eventTime: {
-    marginTop: 2,
-    fontSize: 12,
-    color: "#333",
-    fontWeight: "800",
-  },
-  eventMeta: {
-    marginTop: 2,
-    fontSize: 12,
-    color: "#666",
-    fontWeight: "700",
-  },
-  eventLoc: {
-    marginTop: 2,
-    fontSize: 12,
-    color: "#444",
-    fontWeight: "700",
-  },
-
-  emptyWrap: { padding: 12 },
-  emptyTitle: { fontWeight: "900", fontSize: 13, color: "#111" },
-  emptySub: { marginTop: 4, color: "#666", fontWeight: "600" },
-
-  /* -------- Selected calendars modal -------- */
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.25)",
-    justifyContent: "center",
-    paddingHorizontal: 18,
-  },
-  selectedCalsModal: {
-    backgroundColor: "#fff",
-    borderRadius: 14,
-    padding: 14,
-    borderWidth: 1,
-    borderColor: "#E9E9E9",
-  },
-  selectedCalsHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: 10,
-  },
-  selectedCalsTitle: {
-    fontSize: 16,
-    fontWeight: "900",
-    color: "#111",
-  },
-  selectedCalsList: {
-    maxHeight: 220,
-  },
-  selectedCalsEmpty: {
-    color: "#666",
-    fontWeight: "700",
-    marginVertical: 6,
-  },
-  calRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 8,
-  },
-  colorDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    marginRight: 10,
-  },
-  calName: {
-    flex: 1,
-    fontWeight: "800",
-    color: "#222",
-  },
-  modalActions: {
-    flexDirection: "row",
-    marginTop: 14,
-    justifyContent: "flex-end",
-    gap: 10,
-  },
-  changeBtn: {
-    backgroundColor: "#912338",
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    borderRadius: 10,
-  },
-  changeBtnTxt: {
-    color: "#fff",
-    fontWeight: "900",
-  },
-  disconnectBtn: {
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: "#ccc",
-  },
-  disconnectBtnTxt: {
-    color: "#666",
-    fontWeight: "600",
-  },
-});
 

--- a/client/src/styles/CalendarManuallyAdd_styles.js
+++ b/client/src/styles/CalendarManuallyAdd_styles.js
@@ -1,0 +1,70 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+    overlay: {
+        flex:1,
+        backgroundColor:"rgba(0,0,0,0.4)",
+        justifyContent:"center",
+        alignItems:"center"
+    },
+    container: {
+        width:"90%",
+        backgroundColor:"white",
+        padding:20,
+        borderRadius:10
+    },
+    title: {
+        fontSize:20,
+        fontWeight:"bold",
+        marginBottom:15
+    },
+    input: {
+        borderWidth:1,
+        borderColor:"#ccc",
+        padding:10,
+        borderRadius:6,
+        marginBottom:10},
+    selector: {
+        padding:12,
+        backgroundColor:"#eee",
+        borderRadius:6,
+        marginBottom:10
+    },
+    row: {
+        flexDirection:"row",
+        justifyContent:"space-between",
+        marginTop:10
+    },
+    cancel: {
+        backgroundColor:"#999",
+        padding:10,
+        borderRadius:6,
+        width:"45%",
+        alignItems:"center"
+    },
+    save: {
+        backgroundColor:"#912338",
+        padding:10,
+        borderRadius:6,
+        width:"45%",
+        alignItems:"center"
+    },
+    btnText: {
+        color:"white",
+        fontWeight:"bold"
+    },
+    suggestionsBox: {
+        backgroundColor: "white",
+        borderWidth: 1,
+        borderColor: "#ddd",
+        borderRadius: 6,
+        maxHeight: 150,
+        marginBottom: 10,
+        elevation: 5
+    },
+    suggestionItem: {
+        padding: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: "#eee"
+    },
+});

--- a/client/src/styles/CalendarPage_styles.js
+++ b/client/src/styles/CalendarPage_styles.js
@@ -1,0 +1,319 @@
+import { StyleSheet, Dimensions } from "react-native";
+
+const { height, width } = Dimensions.get("window");
+const SHEET_HEIGHT = height * 0.6;
+
+export const styles = StyleSheet.create({
+  container: { flex: 1 },
+
+  header: {
+    height: 100,
+    backgroundColor: "#912338",
+    paddingTop: 35,
+    paddingHorizontal: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  headerBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+
+  buttonModalUp: {
+    backgroundColor: "#912338",
+    padding: 12,
+    borderRadius: 50,
+    position: "absolute",
+    bottom: 25,
+    right: 15,
+    justifyContent: "center",
+  },
+
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  sheet: {
+    height: SHEET_HEIGHT,
+    backgroundColor: "white",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 20,
+    justifyContent: "center",
+    flexDirection: "column",
+    gap: 20,
+  },
+  handle: {
+    width: 50,
+    height: 6,
+    backgroundColor: "#ccc",
+    borderRadius: 10,
+    alignSelf: "center",
+    position: "absolute",
+    top: 10,
+    marginBottom: 15,
+  },
+  closeBtn: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    zIndex: 12,
+  },
+
+  googleCalBtn: {
+    backgroundColor: "#912338",
+    padding: 12,
+    borderRadius: 50,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  manualBtn: {
+    backgroundColor: "#912338",
+    padding: 12,
+    borderRadius: 50,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  btnTxt: { color: "white", fontWeight: "bold" },
+
+  calendar: {
+    width: 150,
+    height: 150,
+    marginBottom: 10,
+    borderRadius: 45,
+  },
+  txtNoCal: { fontSize: 30, fontWeight: "700" },
+  noCalContainer: {
+    flex: 1,
+    justifyContent: "flex-start",
+    alignItems: "center",
+    marginTop: 220,
+  },
+
+  titleView: {
+    backgroundColor: "#912338",
+    width: width,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  txtTitle: {
+    color: "white",
+    fontSize: 18,
+    bottom: 30,
+    fontWeight: "800",
+    fontFamily: "Helvetica Neue",
+  },
+  selectCalView: {
+    flex: 1,
+    width: "100%",
+    paddingTop: 20,
+    paddingHorizontal: 20,
+  },
+  txtSelectCal: {
+    fontSize: 18,
+    fontWeight: "700",
+    fontFamily: "Helvetica Neue",
+    marginBottom: 10,
+  },
+  checkboxRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 10,
+    paddingHorizontal: 15,
+  },
+  checkboxLabel: { marginLeft: 10, fontSize: 16 },
+  saveBtn: {
+    backgroundColor: "#912338",
+    padding: 15,
+    borderRadius: 10,
+    marginTop: 50,
+    alignItems: "center",
+  },
+
+  /* -------- Calendar page -------- */
+  pageWrap: {
+    flex: 1,
+    paddingTop: 12,
+    paddingHorizontal: 18,
+  },
+  calendarCard: {
+    borderWidth: 1,
+    borderColor: "#E9E9E9",
+    borderRadius: 16,
+    backgroundColor: "#fff",
+    padding: 10,
+  },
+  calendarTopRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 6,
+    paddingTop: 2,
+    paddingBottom: 6,
+  },
+  iconBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  upcomingTitle: {
+    marginTop: 14,
+    marginBottom: 10,
+    fontSize: 16,
+    fontWeight: "800",
+    color: "#111",
+  },
+  upcomingBox: {
+    borderWidth: 1,
+    borderColor: "#E9E9E9",
+    borderRadius: 14,
+    backgroundColor: "#fff",
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    maxHeight: height * 0.36,
+  },
+
+  eventRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingRight: 6,
+    borderRadius: 10,
+  },
+  leftAccent: {
+    width: 3,
+    height: "70%",
+    backgroundColor: "#912338",
+    borderRadius: 4,
+    marginRight: 10,
+    marginLeft: 6,
+  },
+  dateCol: {
+    width: 46,
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: 12,
+  },
+  dateDay: {
+    fontSize: 18,
+    fontWeight: "900",
+    color: "#912338",
+    lineHeight: 20,
+  },
+  dateMonth: {
+    fontSize: 12,
+    fontWeight: "900",
+    color: "#912338",
+    marginTop: 2,
+  },
+  eventInfo: { flex: 1 },
+  eventName: { fontSize: 14, fontWeight: "900", color: "#111" },
+  eventTime: {
+    marginTop: 2,
+    fontSize: 12,
+    color: "#333",
+    fontWeight: "800",
+  },
+  eventMeta: {
+    marginTop: 2,
+    fontSize: 12,
+    color: "#666",
+    fontWeight: "700",
+  },
+  eventLoc: {
+    marginTop: 2,
+    fontSize: 12,
+    color: "#444",
+    fontWeight: "700",
+  },
+
+  emptyWrap: { padding: 12 },
+  emptyTitle: { fontWeight: "900", fontSize: 13, color: "#111" },
+  emptySub: { marginTop: 4, color: "#666", fontWeight: "600" },
+
+  /* -------- Selected calendars modal -------- */
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.25)",
+    justifyContent: "center",
+    paddingHorizontal: 18,
+  },
+  selectedCalsModal: {
+    backgroundColor: "#fff",
+    borderRadius: 14,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: "#E9E9E9",
+  },
+  selectedCalsHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 10,
+  },
+  selectedCalsTitle: {
+    fontSize: 16,
+    fontWeight: "900",
+    color: "#111",
+  },
+  selectedCalsList: {
+    maxHeight: 220,
+  },
+  selectedCalsEmpty: {
+    color: "#666",
+    fontWeight: "700",
+    marginVertical: 6,
+  },
+  calRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+  colorDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    marginRight: 10,
+  },
+  calName: {
+    flex: 1,
+    fontWeight: "800",
+    color: "#222",
+  },
+  modalActions: {
+    flexDirection: "row",
+    marginTop: 14,
+    justifyContent: "flex-end",
+    gap: 10,
+  },
+  changeBtn: {
+    backgroundColor: "#912338",
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+  },
+  changeBtnTxt: {
+    color: "#fff",
+    fontWeight: "900",
+  },
+  disconnectBtn: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#ccc",
+  },
+  disconnectBtnTxt: {
+    color: "#666",
+    fontWeight: "600",
+  },
+});
+


### PR DESCRIPTION
Description :
- Implemented "manually add event" button in calendarPage (was a code TODO)
- Clicking the button brings a pop up allowing input of event name, location (with autocomplete) & room, date and start/end times
- Minor refactoring of the styles/stylesheet of CalendarPage


Currently an issue (need help):
- Adding a manual event without actually connecting to google calendar does not display the events (nor the calendar UI), although the logs show event has been added
- Persistence, leaving the calendar page and coming back wipes the manual events

Checklist:

- [ ] Please make sure to move .env to root and follow new file structure and npm install wherever necessary (recent major change)
- [ ] npm install @react-native-community/datetimepicker

- [ ] Go to hamburger menu, Calendar, bottom right arrow up button popup

- [ ] Make sure you are connected to google calendar and the calendar UI shows

- [ ] Click on Manually Add Events and add required fields. Location is mandatory to avoid users adding non concordia related events, end time is also checked to not be before/equal start time, date is currently not checked (you can add events to the past) and likely will become a future TODO

What should still be working:


Everything should still be working, otherwise please refer to the need help section