### PR TITLE
Refactoring: removed unused imports

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -2,7 +2,7 @@ import { StatusBar } from "expo-status-bar";
 import { buildRouteFromResponse } from './src/services/routeServices';
 import { resolveEventDestination } from './src/services/eventServices';
 import { StyleSheet, View, Pressable } from "react-native";
-import React, { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import * as Location from "expo-location";
 import { Ionicons } from "@expo/vector-icons";
 import CampusMap from "./src/Map";

--- a/client/src/CalendarPage.js
+++ b/client/src/CalendarPage.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -27,7 +27,7 @@ import styles from "./styles/CalendarPage_styles";
 WebBrowser.maybeCompleteAuthSession();
 
 const SAVED_CALENDAR_IDS_KEY = "where2go_saved_calendar_ids";
-const { height, width } = Dimensions.get("window");
+const { height } = Dimensions.get("window");
 
 const SHEET_HEIGHT = height * 0.6;
 

--- a/client/src/ErrorModal.js
+++ b/client/src/ErrorModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, StyleSheet, Pressable, Modal } from "react-native";
 import { Ionicons } from "@expo/vector-icons";

--- a/client/src/LoadingPage.js
+++ b/client/src/LoadingPage.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { View, Image, ActivityIndicator, StyleSheet } from "react-native";
 
 export default function LoadingPage() {

--- a/client/src/Login.js
+++ b/client/src/Login.js
@@ -1,5 +1,4 @@
-import React from "react";
-import { View, Text, ImageBackground, StyleSheet, TouchableOpacity, Image } from "react-native";
+import { View, Text, ImageBackground, TouchableOpacity, Image } from "react-native";
 import PropTypes from 'prop-types';
 import styles from "./styles/Login_styles";
 

--- a/client/src/OutdoorDirection.js
+++ b/client/src/OutdoorDirection.js
@@ -3,7 +3,7 @@ import {
   ImageBackground, ScrollView, ActivityIndicator, Keyboard,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import PropTypes from "prop-types";
 import * as Location from "expo-location";
 import ErrorModal from "./ErrorModal";

--- a/client/src/PoiInfoModal.js
+++ b/client/src/PoiInfoModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Modal,
   View,
@@ -6,7 +5,6 @@ import {
   Image,
   ScrollView,
   Pressable,
-  StyleSheet,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { Ionicons } from '@expo/vector-icons';

--- a/client/src/RouteDetailSheet.js
+++ b/client/src/RouteDetailSheet.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { View, Text, Pressable } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import PropTypes from "prop-types";

--- a/client/src/SideLeftBar.js
+++ b/client/src/SideLeftBar.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import {
   View,
   Text,


### PR DESCRIPTION
### Description

This PR cleans up unused imports

### Checklist:

- [ ] Unused React import removed from App.js
- [ ] Unused React import removed from CalendarPage.js
- [ ] Unused React width variable removed from CalendarPage.js
- [ ] Unused React import removed from LoadingPage.js
- [ ] Unused StyleSheet import removed from Login.js
- [ ] Unused React and Stylesheet import removed from OutdoorDirection.js and PoiInfoModal
- [ ] Unused React import removed from RouteDetailSheet.js
- [ ] Unused React import removed from SideLeftBar.js

### What should still be working:
All features must be working properly
UI should remain unchanged and behave the same

closes #254 